### PR TITLE
Fix Timeout connect on linux

### DIFF
--- a/src/TcpSocket.cpp
+++ b/src/TcpSocket.cpp
@@ -165,10 +165,13 @@ int TcpSocket::connect(const std::string& ipaddr, std::uint16_t port, std::chron
     }
 #else
     {
+      int       selectRet = ret;
+
       int       so_error;
       socklen_t len = sizeof(so_error);
       ::getsockopt(m_pSockRecord->socket(), SOL_SOCKET, SO_ERROR, &ret, &len);
-      if (ret != 0)
+      
+      if (selectRet <= 0 || ret != 0)
       {
         ::close(m_pSockRecord->socket());
         m_pSockRecord->invalidate();


### PR DESCRIPTION


Hello,

We encounter a problem when we try to connect to an ip address where there is no camera. We've tested your visionary_welcome example on linux and when we run the command ./welcome -i192.168.16.52 -dVisionary-T_Mini with no visionary connected to this address, the open function does not return false after the specified "connectTimeout" value has expired (or 5s if this value is not specified by looking at the defaults), it can take a lot longer than this value.
Is this the maximum time the open function should take before returning anything?

We've also noticed that when there's something at this address (e.g. a computer on the same network), the open function immediately returns false.

Here is a suggested fix for this problem

Thank you in advance for your time,
